### PR TITLE
Add remove-hook command and documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,138 @@
 # AL2DBML
+
 Generates a DBML database schema from a Business Central AL project by parsing table and field definitions.
+
+## Prerequisites
+
+No runtime required — AL2DBML is distributed as a self-contained binary.
+
+| Platform | Supported |
+|---|---|
+| Windows (x64) | ✓ |
+| macOS (Apple Silicon) | ✓ |
+| Linux (x64) | ✓ |
+
+## Installation
+
+### Windows (PowerShell)
+
+```powershell
+$dest = "$env:LOCALAPPDATA\al2dbml"
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+Invoke-WebRequest -Uri "https://github.com/OGR-67/AL2DBML/releases/latest/download/al2dbml-win-x64.exe" -OutFile "$dest\al2dbml.exe"
+$path = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($path -notlike "*al2dbml*") {
+    [Environment]::SetEnvironmentVariable("Path", "$path;$dest", "User")
+}
+Write-Host "Done. Restart your terminal."
+```
+
+### macOS
+
+```bash
+curl -L https://github.com/OGR-67/AL2DBML/releases/latest/download/al2dbml-osx-arm64 -o al2dbml
+chmod +x al2dbml
+xattr -d com.apple.quarantine al2dbml
+sudo mv al2dbml /usr/local/bin/al2dbml
+```
+
+> **Note:** The `xattr` command removes the Gatekeeper quarantine flag that macOS sets on downloaded binaries. Without it, macOS will block the app on first run. If you downloaded the binary manually instead of using this script, go to **System Settings → Privacy & Security** and click **Allow Anyway**.
+
+### Linux
+
+```bash
+curl -L https://github.com/OGR-67/AL2DBML/releases/latest/download/al2dbml-linux-x64 -o al2dbml
+chmod +x al2dbml
+sudo mv al2dbml /usr/local/bin/al2dbml
+```
+
+## Quick start
+
+```bash
+# 1. Initialize AL2DBML in your project (run once)
+al2dbml init
+
+# 2. Generate the DBML schema
+al2dbml generate
+```
+
+## Commands
+
+### `generate`
+
+Parses AL files and generates a `.dbml` schema file.
+
+```
+al2dbml generate [-i <input>] [-o <output>] [-n <name>]
+```
+
+| Option | Description | Default |
+|---|---|---|
+| `-i`, `--input` | Path to an AL project folder, `.al` file, or `.code-workspace` file | Value from `config.local.json`, then `.` |
+| `-o`, `--output` | Output directory | Value from `config.json`, then `.` |
+| `-n`, `--name` | Output file name (without extension) | Value from `config.json`, then `schema` |
+
+### `init`
+
+Initializes AL2DBML interactively in the current directory. Creates the `.al2dbml/` config folder and optionally sets up a pre-commit hook.
+
+```
+al2dbml init
+```
+
+Re-running `init` on an existing config pre-fills the prompts with current values.
+
+## Configuration
+
+`init` creates two files in `.al2dbml/`:
+
+| File | Versioned | Content |
+|---|---|---|
+| `config.json` | Yes | Output path and file name — shared across contributors |
+| `config.local.json` | No (gitignored) | Input path — contributor-specific, useful for workspaces |
+
+`config.json` example:
+```json
+{
+  "Output": {
+    "Path": "./docs/",
+    "Name": "schema"
+  }
+}
+```
+
+`config.local.json` example:
+```json
+{
+  "Input": {
+    "Path": "./MyProject.code-workspace"
+  }
+}
+```
+
+## Pre-commit hook
+
+When enabled during `init`, AL2DBML adds a section to `.git/hooks/pre-commit` that automatically regenerates the schema on each commit:
+
+```sh
+# [al2dbml-start]
+if command -v al2dbml > /dev/null 2>&1; then
+    al2dbml generate || printf "\033[33mWarning: al2dbml generate failed, skipping DBML update.\033[0m\n"
+else
+    printf "\033[33mWarning: al2dbml not found, skipping DBML update.\033[0m\n"
+fi
+# [al2dbml-end]
+```
+
+If `al2dbml` is not installed on a contributor's machine, the hook prints a warning and lets the commit proceed normally.
+
+To remove the hook, run:
+
+```bash
+al2dbml remove-hook
+```
+
+## Contributing
+
+- [Architecture](docs/ARCHITECTURE.md) — project structure, CLI design, DI setup
+- [AL Parsing](docs/AL_PARSING.md) — AL syntax specifics and parsing decisions

--- a/docs/AL_PARSING.md
+++ b/docs/AL_PARSING.md
@@ -1,0 +1,107 @@
+# AL File Parsing
+
+This document describes the AL parsing specifics relevant to this project. It does not cover the full AL language specification — only what is needed to generate DBML output.
+
+## Supported file types
+
+| AL type | Detection keyword | Handled by |
+|---|---|---|
+| Table | `table` | `ParseTable` |
+| Table extension | `tableextension` | `ParseTableExtension` |
+| Enum | `enum` | `ParseEnum` |
+| Enum extension | `enumextension` | `ParseEnumExtension` |
+| Other (page, report, codeunit...) | — | Silently skipped |
+
+## File type detection
+
+Detection is done by regex on the **file content**, not the filename or extension. The detection order matters:
+
+1. `enumextension` before `enum` — an extension file could partially match the enum pattern
+2. `tableextension` before `table` — same reason
+
+## Object identifiers
+
+Every AL object has a numeric ID: `table 50100 "Customer"`. The ID is **ignored** — only the name is extracted and used in the DBML output.
+
+## Name conventions
+
+AL identifiers can be quoted or unquoted:
+- `"My Field"` → quoted, typically used for names with spaces or special characters
+- `MyField` → unquoted
+
+Names containing `/` must be re-quoted in DBML output (e.g. `"No./Name"`) since `/` is not valid in an unquoted DBML identifier. This is handled by `AlSyntaxHelper.CleanName`.
+
+## Table parsing
+
+### Fields
+
+AL field syntax:
+```al
+field(50; "My Field"; Text[100]) { ... }
+```
+
+The field body `{ ... }` is parsed for:
+- `FieldClass = FlowField` → marks the column as a FlowField
+- `CalcFormula = ...` → extracts the formula as a string
+
+### Primary keys
+
+Primary keys are detected from `key(...)` declarations:
+- A key named `PK` is treated as the primary key
+- A key with `Clustered = true` in its body is treated as the primary key
+- Composite keys (comma-separated fields) are supported
+
+```al
+key(PK; "No.") { Clustered = true; }
+```
+
+## Table extensions
+
+A `tableextension` extends an existing base table:
+```al
+tableextension 50100 "My Extension" extends "Customer" { ... }
+```
+
+Fields from the extension are **merged** into the base table's `DBMLTable`. If the base table has not been parsed yet, a new `DBMLTable` is created for it and will be enriched when the base table file is processed. Parse order across files therefore does not matter.
+
+## Enum parsing
+
+An enum can optionally implement one or more interfaces via the `implements` clause:
+
+```al
+enum 50100 "My Status" implements "IStatus", "ILabel"
+{
+    value(0; Open) { Caption = 'Open'; }
+    value(1; Closed) { Caption = 'Closed'; }
+}
+```
+
+The `implements` clause is handled by the detection regex but the interface names are **not captured** in the output — only the enum name and its values matter for DBML. The corresponding interface definition files (`.al` files containing `interface "IStatus" { ... }`) are `Unknown` type and silently skipped.
+
+### Detection order caveat
+
+The `Enum` detection pattern starts with `^\s*enum\s+`. Since `enumextension` also starts with `enum`, checking `Enum` before `EnumExtension` would misclassify extension files. The correct order is always `EnumExtension` → `Enum`.
+
+## Enum extensions
+
+```al
+enumextension 50101 "My Status Ext" extends "My Status" { value(2; Pending) }
+```
+
+Values are merged into the base enum. Duplicate values are ignored.
+
+## FlowFields
+
+AL FlowFields are calculated fields with no physical storage:
+```al
+field(20; "Balance"; Decimal) {
+    FieldClass = FlowField;
+    CalcFormula = sum("Ledger Entry".Amount where("Account No." = field("No.")));
+}
+```
+
+FlowFields are included in the DBML output as regular columns. The `CalcFormula` is captured and can be used as a note. DBML has no native equivalent for this concept.
+
+## State accumulation
+
+`IAlParser` accumulates parsed tables and enums in internal state across multiple `Parse*` calls. This allows multi-file parsing (folder, workspace) to produce a single unified `OutputSchema`. State is cleared between command executions via `ClearOutputSchema()`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 AL2DBML follows a Clean Architecture pattern: the CLI resolves dependencies through a dedicated Composition Root, while the Parser acts as infrastructure implementing contracts defined by the Application layer — keeping the Domain model free of any external dependency.
 
+## Dependency graph
+
 ```mermaid
 graph TD
     CLI["AL2DBML.CLI<br/><i>Presentation</i>"]
@@ -24,3 +26,63 @@ graph TD
     TESTS --> CORE
     TESTS --> DI
 ```
+
+## CLI layer
+
+The CLI is built on **Spectre.Console.Cli** and exposes two commands:
+
+| Command | Description |
+|---|---|
+| `generate` | Parses AL input and writes a `.dbml` file |
+| `init` | Initializes the `.al2dbml/` config directory interactively |
+
+### Input strategy pattern
+
+`generate` delegates input handling to an `IInputStrategy` resolved by `InputStrategyFactory` based on the detected input type:
+
+```mermaid
+graph TD
+    GC["GenerateCommand"]
+    F["InputStrategyFactory"]
+    SF["SingleFileInputStrategy"]
+    FO["FolderInputStrategy"]
+    WS["WorkspaceInputStrategy"]
+
+    GC --> F
+    F --> SF
+    F --> FO
+    F --> WS
+    FO --> SF
+    WS --> FO
+```
+
+| Strategy | Input | Behaviour |
+|---|---|---|
+| `SingleFileInputStrategy` | `.al` file | Detects file type, calls the appropriate parser method |
+| `FolderInputStrategy` | Directory | Scans for `*.al` recursively, delegates each file to `SingleFileInputStrategy` |
+| `WorkspaceInputStrategy` | `.code-workspace` | Reads workspace JSON, resolves each folder path, delegates to `FolderInputStrategy` |
+
+Files with an unsupported type (`AlFileType.Unknown`) are silently skipped — this is intentional since AL projects contain many non-table/enum objects.
+
+### Configuration
+
+`init` creates a `.al2dbml/` directory at the project root with two files:
+
+| File | Tracked | Content |
+|---|---|---|
+| `config.json` | versioned | output path and file name (shared across contributors) |
+| `config.local.json` | gitignored | input path (contributor-specific, especially for workspaces) |
+
+`generate` reads these files if present; CLI arguments always take precedence.
+
+### Services
+
+| Service | Scope | Responsibility |
+|---|---|---|
+| `FileSystemService` | static | Input type detection, directory scan |
+| `ConfigService` | scoped | Read/write `.al2dbml/` config files |
+| `ParsingTracker` | scoped | Track file count and elapsed time per command execution |
+
+### DI integration
+
+Spectre.Console.Cli is integrated with `Microsoft.Extensions.DependencyInjection` via a custom `TypeRegistrar`/`TypeResolver`. A new DI scope is created per command execution so scoped services (parser state, tracker) are properly isolated.

--- a/src/AL2DBML.CLI/Commands/InitCommand.cs
+++ b/src/AL2DBML.CLI/Commands/InitCommand.cs
@@ -1,3 +1,4 @@
+using AL2DBML.CLI.Constants;
 using AL2DBML.CLI.Models;
 using AL2DBML.CLI.Services;
 using Spectre.Console;
@@ -11,9 +12,6 @@ public class InitSettings : CommandSettings
 
 public class InitCommand : AsyncCommand<InitSettings>
 {
-    private const string HookStartMarker = "# [al2dbml-start]";
-    private const string HookEndMarker = "# [al2dbml-end]";
-    private const string HookCommand = "al2dbml generate";
     private const string GitignoreEntry = ".al2dbml/config.local.json";
 
     private readonly IConfigService _configService;
@@ -44,7 +42,7 @@ public class InitCommand : AsyncCommand<InitSettings>
                 .DefaultValue(existingShared?.Output.Name ?? "schema"));
 
         var hookExists = File.Exists(".git/hooks/pre-commit") &&
-                         File.ReadAllText(".git/hooks/pre-commit").Contains(HookStartMarker, StringComparison.Ordinal);
+                         File.ReadAllText(".git/hooks/pre-commit").Contains(HookMarkers.Start, StringComparison.Ordinal);
         var createHook = AnsiConsole.Confirm("Create a pre-commit hook?", hookExists);
 
         _configService.SaveSharedConfig(new SharedConfig
@@ -59,7 +57,17 @@ public class InitCommand : AsyncCommand<InitSettings>
         EnsureGitignoreEntry(GitignoreEntry);
 
         if (createHook)
-            WritePreCommitHook();
+        {
+            if (!Directory.Exists(".git/hooks"))
+                AnsiConsole.MarkupLine("[yellow]Warning:[/] .git/hooks directory not found — skipping pre-commit hook creation.");
+            else
+                HookService.Write();
+        }
+        else if (hookExists)
+        {
+            AnsiConsole.MarkupLine("[yellow]Removing existing pre-commit hook...[/]");
+            HookService.Remove();
+        }
 
         AnsiConsole.MarkupLine("[green]Done:[/] AL2DBML initialized.");
         return Task.FromResult(0);
@@ -77,42 +85,5 @@ public class InitCommand : AsyncCommand<InitSettings>
 
         lines.Add(entry);
         File.WriteAllLines(gitignorePath, lines);
-    }
-
-    private static void WritePreCommitHook()
-    {
-        const string hookPath = ".git/hooks/pre-commit";
-
-        if (!Directory.Exists(".git/hooks"))
-        {
-            AnsiConsole.MarkupLine("[yellow]Warning:[/] .git/hooks directory not found — skipping pre-commit hook creation.");
-            return;
-        }
-        var hookSection = $"{HookStartMarker}\nif command -v al2dbml > /dev/null 2>&1; then\n    {HookCommand} || printf \"\\033[33mWarning: al2dbml generate failed, skipping DBML update.\\033[0m\\n\"\nelse\n    printf \"\\033[33mWarning: al2dbml not found, skipping DBML update.\\033[0m\\n\"\nfi\n{HookEndMarker}";
-
-        string content;
-        if (File.Exists(hookPath))
-        {
-            content = File.ReadAllText(hookPath);
-            var startIdx = content.IndexOf(HookStartMarker, StringComparison.Ordinal);
-            var endIdx = content.IndexOf(HookEndMarker, StringComparison.Ordinal);
-
-            if (startIdx >= 0 && endIdx >= 0)
-                content = content[..startIdx] + hookSection + content[(endIdx + HookEndMarker.Length)..];
-            else
-                content = content.TrimEnd() + $"\n\n{hookSection}\n";
-        }
-        else
-        {
-            content = $"#!/bin/sh\n\n{hookSection}\n";
-        }
-
-        File.WriteAllText(hookPath, content);
-
-        if (!OperatingSystem.IsWindows())
-            File.SetUnixFileMode(hookPath,
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
     }
 }

--- a/src/AL2DBML.CLI/Commands/RemoveHookCommand.cs
+++ b/src/AL2DBML.CLI/Commands/RemoveHookCommand.cs
@@ -1,0 +1,29 @@
+using AL2DBML.CLI.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AL2DBML.CLI.Commands;
+
+public class RemoveHookSettings : CommandSettings
+{
+}
+
+public class RemoveHookCommand : Command<RemoveHookSettings>
+{
+    protected override int Execute(CommandContext context, RemoveHookSettings settings, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(".git/hooks/pre-commit"))
+        {
+            AnsiConsole.MarkupLine("[yellow]Warning:[/] No pre-commit hook found.");
+            return 0;
+        }
+
+        var removed = HookService.Remove();
+        if (!removed)
+            AnsiConsole.MarkupLine("[yellow]Warning:[/] No AL2DBML section found in pre-commit hook.");
+        else
+            AnsiConsole.MarkupLine("[green]Done:[/] AL2DBML section removed from pre-commit hook.");
+
+        return 0;
+    }
+}

--- a/src/AL2DBML.CLI/Commands/RemoveHookCommand.cs
+++ b/src/AL2DBML.CLI/Commands/RemoveHookCommand.cs
@@ -12,12 +12,6 @@ public class RemoveHookCommand : Command<RemoveHookSettings>
 {
     protected override int Execute(CommandContext context, RemoveHookSettings settings, CancellationToken cancellationToken)
     {
-        if (!File.Exists(".git/hooks/pre-commit"))
-        {
-            AnsiConsole.MarkupLine("[yellow]Warning:[/] No pre-commit hook found.");
-            return 0;
-        }
-
         var removed = HookService.Remove();
         if (!removed)
             AnsiConsole.MarkupLine("[yellow]Warning:[/] No AL2DBML section found in pre-commit hook.");

--- a/src/AL2DBML.CLI/Constants/HookMarkers.cs
+++ b/src/AL2DBML.CLI/Constants/HookMarkers.cs
@@ -1,0 +1,7 @@
+namespace AL2DBML.CLI.Constants;
+
+internal static class HookMarkers
+{
+    public const string Start = "# [al2dbml-start]";
+    public const string End = "# [al2dbml-end]";
+}

--- a/src/AL2DBML.CLI/Program.cs
+++ b/src/AL2DBML.CLI/Program.cs
@@ -23,6 +23,7 @@ app.Configure(config =>
 {
     config.AddCommand<GenerateCommand>("generate");
     config.AddCommand<InitCommand>("init");
+    config.AddCommand<RemoveHookCommand>("remove-hook");
 });
 
 return await app.RunAsync(args);

--- a/src/AL2DBML.CLI/Program.cs
+++ b/src/AL2DBML.CLI/Program.cs
@@ -12,6 +12,7 @@ services
     .AddAL2Dbml()
     .AddScoped<GenerateCommand>()
     .AddScoped<InitCommand>()
+    .AddScoped<RemoveHookCommand>()
     .AddScoped<IParsingTracker, ParsingTracker>()
     .AddScoped<IConfigService, ConfigService>();
 

--- a/src/AL2DBML.CLI/Services/HookService.cs
+++ b/src/AL2DBML.CLI/Services/HookService.cs
@@ -21,7 +21,7 @@ internal static class HookService
             var startIdx = content.IndexOf(HookMarkers.Start, StringComparison.Ordinal);
             var endIdx = content.IndexOf(HookMarkers.End, StringComparison.Ordinal);
 
-            if (startIdx >= 0 && endIdx >= 0)
+            if (startIdx >= 0 && endIdx > startIdx)
                 content = content[..startIdx] + hookSection + content[(endIdx + HookMarkers.End.Length)..];
             else
                 content = content.TrimEnd() + $"\n\n{hookSection}\n";
@@ -47,7 +47,7 @@ internal static class HookService
         var content = File.ReadAllText(HookPath);
         var startIdx = content.IndexOf(HookMarkers.Start, StringComparison.Ordinal);
         var endIdx = content.IndexOf(HookMarkers.End, StringComparison.Ordinal);
-        if (startIdx < 0 || endIdx < 0) return false;
+        if (startIdx < 0 || endIdx <= startIdx) return false;
 
         var before = content[..startIdx].TrimEnd();
         var after = content[(endIdx + HookMarkers.End.Length)..].TrimStart('\r', '\n');

--- a/src/AL2DBML.CLI/Services/HookService.cs
+++ b/src/AL2DBML.CLI/Services/HookService.cs
@@ -1,0 +1,65 @@
+using AL2DBML.CLI.Constants;
+
+namespace AL2DBML.CLI.Services;
+
+internal static class HookService
+{
+    private const string HookPath = ".git/hooks/pre-commit";
+    private const string HookCommand = "al2dbml generate";
+
+    public static void Write()
+    {
+        if (!Directory.Exists(".git/hooks"))
+            return;
+
+        var hookSection = $"{HookMarkers.Start}\nif command -v al2dbml > /dev/null 2>&1; then\n    {HookCommand} || printf \"\\033[33mWarning: al2dbml generate failed, skipping DBML update.\\033[0m\\n\"\nelse\n    printf \"\\033[33mWarning: al2dbml not found, skipping DBML update.\\033[0m\\n\"\nfi\n{HookMarkers.End}";
+
+        string content;
+        if (File.Exists(HookPath))
+        {
+            content = File.ReadAllText(HookPath);
+            var startIdx = content.IndexOf(HookMarkers.Start, StringComparison.Ordinal);
+            var endIdx = content.IndexOf(HookMarkers.End, StringComparison.Ordinal);
+
+            if (startIdx >= 0 && endIdx >= 0)
+                content = content[..startIdx] + hookSection + content[(endIdx + HookMarkers.End.Length)..];
+            else
+                content = content.TrimEnd() + $"\n\n{hookSection}\n";
+        }
+        else
+        {
+            content = $"#!/bin/sh\n\n{hookSection}\n";
+        }
+
+        File.WriteAllText(HookPath, content);
+
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(HookPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+    }
+
+    public static bool Remove()
+    {
+        if (!File.Exists(HookPath)) return false;
+
+        var content = File.ReadAllText(HookPath);
+        var startIdx = content.IndexOf(HookMarkers.Start, StringComparison.Ordinal);
+        var endIdx = content.IndexOf(HookMarkers.End, StringComparison.Ordinal);
+        if (startIdx < 0 || endIdx < 0) return false;
+
+        var before = content[..startIdx].TrimEnd();
+        var after = content[(endIdx + HookMarkers.End.Length)..].TrimStart('\r', '\n');
+        var newContent = before.Length > 0 && after.Length > 0
+            ? before + "\n\n" + after
+            : (before + after).Trim();
+
+        if (string.IsNullOrWhiteSpace(newContent.Replace("#!/bin/sh", "")))
+            File.Delete(HookPath);
+        else
+            File.WriteAllText(HookPath, newContent + "\n");
+
+        return true;
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements to the AL2DBML project, focusing on enhanced documentation, a more robust and modular approach for managing the pre-commit Git hook, and improved CLI usability. The most significant changes are the extraction of hook logic into a dedicated service, the addition of a new CLI command for removing the hook, and comprehensive updates to the documentation for both users and contributors.

**Key improvements:**

### Pre-commit hook management

* Extracted all logic for writing and removing the pre-commit hook into a new static `HookService`, replacing the previous inline implementation. This makes the codebase more modular and maintainable. (`src/AL2DBML.CLI/Services/HookService.cs`, `src/AL2DBML.CLI/Commands/InitCommand.cs`) [[1]](diffhunk://#diff-20c5028eef19f1b2d2b96df28505b38e43b90b6eac3c90108202ff7828806411R1-R65) [[2]](diffhunk://#diff-0bf33bd823e294a0e38a61a5aad86dd6069ce784814544af57e2e9cd74c1df83R1) [[3]](diffhunk://#diff-0bf33bd823e294a0e38a61a5aad86dd6069ce784814544af57e2e9cd74c1df83L14-L16) [[4]](diffhunk://#diff-0bf33bd823e294a0e38a61a5aad86dd6069ce784814544af57e2e9cd74c1df83L47-R45) [[5]](diffhunk://#diff-0bf33bd823e294a0e38a61a5aad86dd6069ce784814544af57e2e9cd74c1df83L62-R70) [[6]](diffhunk://#diff-0bf33bd823e294a0e38a61a5aad86dd6069ce784814544af57e2e9cd74c1df83L81-L117)
* Added a new CLI command `remove-hook` for easily removing the AL2DBML section from the pre-commit hook, with appropriate user feedback. (`src/AL2DBML.CLI/Commands/RemoveHookCommand.cs`, `src/AL2DBML.CLI/Program.cs`) [[1]](diffhunk://#diff-5950198a814da503f9ba099c862f739931c3f45f116f61ee58d8b248873edcd1R1-R23) [[2]](diffhunk://#diff-23553fc4eb3af243e29fda5d757142ab627e3d32dcbbb59e88ce6b84727fa745R15) [[3]](diffhunk://#diff-23553fc4eb3af243e29fda5d757142ab627e3d32dcbbb59e88ce6b84727fa745R27)
* Centralized hook section markers in a new `HookMarkers` constants class to avoid duplication and ensure consistency. (`src/AL2DBML.CLI/Constants/HookMarkers.cs`)

### Documentation improvements

* Expanded the `README.md` with detailed installation instructions for Windows, macOS, and Linux, quick start steps, command usage, configuration details, and pre-commit hook behavior.
* Added a new `docs/AL_PARSING.md` file describing AL file parsing logic, supported object types, detection order, and how parser state is accumulated.
* Enhanced `docs/ARCHITECTURE.md` with a dependency graph, detailed CLI architecture, input strategy pattern, configuration, service responsibilities, and DI integration. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R5-R6) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R29-R88)

These changes make AL2DBML easier to install, configure, and use, while also making the codebase cleaner and more maintainable for future development.